### PR TITLE
Always clear current guess when changing word length

### DIFF
--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -153,6 +153,7 @@ function Game(props: GameProps) {
             setGameNumber(1);
             setGameState(GameState.Playing);
             setGuesses([]);
+            setCurrentGuess("");
             setTarget(randomTarget(length));
             setWordLength(length);
             setHint(`${length} letters`);


### PR DESCRIPTION
There's a bug with changing the length of a guess as long as `currentGuess` is non-empty. This fixes that:

![156D081B-8A89-4297-9EBA-A15126895891](https://user-images.githubusercontent.com/1081744/149610796-f3b560af-11a7-41dc-944a-c7c384f7b489.gif)
