### PR TITLE
Add the word "stire" to the dictionary

### DIFF
--- a/src/dictionary.json
+++ b/src/dictionary.json
@@ -150980,6 +150980,7 @@
   "stir",
   "stirabout",
   "stirabouts",
+  "stire",
   "stirk",
   "stirks",
   "stirp",


### PR DESCRIPTION
The word "stire" is a valid word in the original Wordle game, but it isn't a valid word in Wordl.