### PR TITLE
Ultra Hard: prevent using letter in a previously grey position

### DIFF
--- a/src/clue.ts
+++ b/src/clue.ts
@@ -72,6 +72,9 @@ export function violation(
     const nth = ordinal(i + 1);
     if (clue === Clue.Absent) {
       if (difficulty === Difficulty.UltraHard) {
+        if (guess[i] === letter) {
+          return nth + " letter can't be " + upper;
+        }
         const max = clues.filter(
           (c) => c.letter === letter && c.clue !== Clue.Absent
         ).length;


### PR DESCRIPTION
For example, with a target word of RALLY ([challenge link]), guessing ARRAY gives [elsewhere, elsewhere, absent, absent, correct].
This commit makes guessing SPRAY a violation, as we know that A cannot be in the first or fourth positions (or else one of them would be correct), and R cannot be in the second or third positions.

Before:
<details>
<summary>Image showing SPRAY guessed after ARRAY</summary>
<img src="https://user-images.githubusercontent.com/6015058/150660466-c0f8129b-d732-4c5a-866c-983c56ff6da7.png">
</details>

After:
<details>
<summary>Image showing SPRAY cannot be guessed after ARRAY as "3rd letter can't be R"</summary>
<img src="https://user-images.githubusercontent.com/6015058/150660481-636cb4c5-8e83-4454-af1b-2a02b3403d32.png">
</details>

[challenge link]: https://hellowordl.net/?challenge=cmFsbHk