### PR TITLE
Ultra Hard: enforce letter counts even without absent clues

### DIFF
--- a/src/clue.ts
+++ b/src/clue.ts
@@ -70,19 +70,7 @@ export function violation(
   for (const { letter, clue } of clues) {
     const upper = letter.toUpperCase();
     const nth = ordinal(i + 1);
-    if (clue === Clue.Absent) {
-      if (difficulty === Difficulty.UltraHard) {
-        const max = clues.filter(
-          (c) => c.letter === letter && c.clue !== Clue.Absent
-        ).length;
-        const count = guess.split(letter).length - 1;
-        if (count > max) {
-          const amount = max ? `more than ${englishNumbers[max]} ` : "";
-          const s = max > 1 ? "s" : "";
-          return `Guess can't contain ${amount}${upper}${s}`;
-        }
-      }
-    } else if (clue === Clue.Correct) {
+    if (clue === Clue.Correct) {
       if (guess[i] !== letter) {
         return nth + " letter must be " + upper;
       }
@@ -91,6 +79,30 @@ export function violation(
         return "Guess must contain " + upper;
       } else if (difficulty === Difficulty.UltraHard && guess[i] === letter) {
         return nth + " letter can't be " + upper;
+      }
+    }
+    if (difficulty === Difficulty.UltraHard) {
+      const clueCount = clues.filter(
+        (c) => c.letter === letter && c.clue !== Clue.Absent
+      ).length;
+      const guessCount = guess.split(letter).length - 1;
+      const hasAbsent = clues.some(
+        (c) => c.letter === letter && c.clue === Clue.Absent
+      );
+      const amount = englishNumbers[clueCount];
+      const s = clueCount !== 1 ? "s" : "";
+      if (hasAbsent) {
+        if (guessCount !== clueCount) {
+          if (clueCount === 0) {
+            return `Guess can't contain ${upper}`;
+          } else {
+            return `Guess must contain exactly ${amount} ${upper}${s}`;
+          }
+        }
+      } else {
+        if (guessCount < clueCount) {
+          return `Guess must contain at least ${amount} ${upper}${s}`;
+        }
       }
     }
     ++i;


### PR DESCRIPTION
For example, with a target word of RALLY ([challenge link]), guessing LEVEL gives [elsewhere, absent, absent, absent, elsewhere].
This commit makes guessing WORLD afterwards a violation, as there must be at least two Ls in the target word.

This commit also makes it clearer that, when there is an absent clue, the count of the letter must be exactly (number of non-absent clues with that letter).

Before:
<details>
<summary>Image showing WORLD guessed after LEVEL</summary>
<img src="https://user-images.githubusercontent.com/6015058/150676947-4c98d6eb-d69f-4380-9d7d-d78c5da97065.png">
</details>

After:
<details>
<summary>Image showing WORLD cannot be guessed after LEVEL as "Guess must contain at least two Ls"</summary>
<img src="https://user-images.githubusercontent.com/6015058/150676937-4847fbe1-9b6d-4849-89c8-9952a96483de.png">
</details>


[challenge link]: https://hellowordl.net/?challenge=cmFsbHk