### PR TITLE
feat: difficulty stars in emoji share

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ function App() {
     "qwertyuiop-asdfghjkl-BzxcvbnmE"
   );
   const [enterLeft, setEnterLeft] = useSetting<boolean>("enter-left", false);
+  const [ongoing, setOngoing] = useState<boolean>(false);
 
   useEffect(() => {
     document.body.className = dark ? "dark" : "";
@@ -133,6 +134,7 @@ function App() {
               max="2"
               value={difficulty}
               onChange={(e) => setDifficulty(+e.target.value)}
+              disabled={ongoing === true}
             />
             <div>
               <label htmlFor="difficulty-setting">Difficulty:</label>
@@ -189,6 +191,7 @@ function App() {
           /[BE]/g,
           (x) => (enterLeft ? "EB" : "BE")["BE".indexOf(x)]
         )}
+        setOngoing={setOngoing}
       />
     </div>
   );


### PR DESCRIPTION
adds asterisks(one for hard, two for ultrahard) based on the difficulty the game is played in.
- `ongoing` exists to disable difficulty change once the game has started. this is technically redundancy but feels better than lifting the whole game logic up.
- `currentDifficulty` exists to preserve state where user solves the puzzle, changes the difficulty, then shares the puzzle without restarting.
![Screenshot](https://github.com/lynn/hello/assets/38210271/ce5010b4-1796-4548-bcb8-b60ad345ce64)
